### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- preserve the existing `prConcurrentLimit: 5`

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

Note: I did not run `atmos test run` because this repository's `AGENTS.md` says the Terratest suite deploys/destroys real AWS resources and may incur AWS cost; this PR only changes Renovate configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to apply recommended preset rules and settings, which may affect how and when dependency updates are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->